### PR TITLE
add support for filtering integrations by description

### DIFF
--- a/plugin/providers/runscope/data_source_runscope_integration.go
+++ b/plugin/providers/runscope/data_source_runscope_integration.go
@@ -20,6 +20,10 @@ func dataSourceRunscopeIntegration() *schema.Resource {
 				Type:     schema.TypeString,
 				Required: true,
 			},
+			"description": {
+				Type:     schema.TypeString,
+				Computed: true,
+			},
 		},
 	}
 }
@@ -45,12 +49,13 @@ func dataSourceRunscopeIntegrationRead(d *schema.ResourceData, meta interface{})
 	}
 
 	if found == nil {
-		return fmt.Errorf("Unable to locate any user with the email: %s", searchType)
+		return fmt.Errorf("Unable to locate any integrations with the type: %s", searchType)
 	}
 
 	d.SetId(found.ID)
 	d.Set("id", found.ID)
 	d.Set("type", found.IntegrationType)
+	d.Set("description", found.Description)
 
 	return nil
 }

--- a/plugin/providers/runscope/data_source_runscope_integration_test.go
+++ b/plugin/providers/runscope/data_source_runscope_integration_test.go
@@ -40,6 +40,10 @@ func testAccDataSourceRunscopeIntegration(dataSource string) resource.TestCheckF
 			return fmt.Errorf("Expected to get an integration type slack from runscope data resource")
 		}
 
+		if a["description"] == "" {
+			return fmt.Errorf("Expected to get an integration description from runscope data resource")
+		}
+
 		return nil
 	}
 }

--- a/plugin/providers/runscope/data_source_runscope_integration_test.go
+++ b/plugin/providers/runscope/data_source_runscope_integration_test.go
@@ -54,3 +54,47 @@ data "runscope_integration" "by_type" {
 	type      = "slack"
 }
 `
+
+func TestAccDataSourceRunscopeIntegration_Filter(t *testing.T) {
+
+	teamId := os.Getenv("RUNSCOPE_TEAM_ID")
+	integrationDesc := os.Getenv("RUNSCOPE_INTEGRATION_DESC")
+
+	resource.Test(t, resource.TestCase{
+		PreCheck:  func() { testAccPreCheck(t) },
+		Providers: testAccProviders,
+		Steps: []resource.TestStep{
+			{
+				Config: fmt.Sprintf(testAccDataSourceRunscopeIntegrationFilterConfig, teamId, integrationDesc),
+				Check: resource.ComposeTestCheckFunc(
+					testAccDataSourceRunscopeIntegrationFilter("data.runscope_integration.by_type"),
+				),
+			},
+		},
+	})
+}
+
+func testAccDataSourceRunscopeIntegrationFilter(dataSource string) resource.TestCheckFunc {
+	return func(s *terraform.State) error {
+		r := s.RootModule().Resources[dataSource]
+		a := r.Primary.Attributes
+		integrationDesc := os.Getenv("RUNSCOPE_INTEGRATION_DESC")
+
+		if a["description"] != integrationDesc {
+			return fmt.Errorf("Expected integration description %s to be %s", a["description"], integrationDesc)
+		}
+
+		return nil
+	}
+}
+
+const testAccDataSourceRunscopeIntegrationFilterConfig = `
+data "runscope_integration" "by_type" {
+	team_uuid = "%s"
+	type      = "slack"
+	filter = {
+		name = "description"
+		values = ["%s","other test description"]
+	}
+}
+`


### PR DESCRIPTION
requires additional `RUNSCOPE_INTEGRATION_DESC` env to be provided